### PR TITLE
Add python3 to the image so that precommit can work

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -30,7 +30,7 @@ RUN groupadd --gid $JENKINS_GID jenkins && \
 RUN export DEBIAN_FRONTEND=noninteractive TERM=linux && \
   apt-get update && \
   apt-get -y install apt-utils ant unzip git && \
-  apt-get -y --no-install-recommends install libfontconfig1 && \
+  apt-get -y --no-install-recommends install libfontconfig1 python3 && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
Simple change that adds python3 to the package installed by default. This is essential to be able to run "ant precommit" on the image.